### PR TITLE
Switch back to 10.30

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pcre2" %}
-{% set version = "10.23" %}
-{% set sha256 = "bd62f955146a41815d6e2ce011bb75740825c32906b06e377f478599f54ee0dd" %}
+{% set version = "10.30" %}
+{% set sha256 = "b549873a39f804480c2e6145a78adcba53e38162d90ef6ea92384f6ecf2fde76" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Was the latest version in the feedstock. So we should resurrect it. Created branches for all of the legacy versions.