### PR TITLE
Enable JIT (10.21)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-./configure --prefix=$PREFIX
+./configure --prefix="${PREFIX}"
 make
 make check
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 ./configure \
     --prefix="${PREFIX}" \
+    --enable-jit \
 
 make
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 ./configure --prefix="${PREFIX}"
 make
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-./configure --prefix="${PREFIX}"
+./configure \
+    --prefix="${PREFIX}" \
+
 make
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
Build PCRE2 with JIT support. This is how Julia builds PCRE2 and we need to be compatible with their build so as to build Julia itself with this. Hence we enable JIT support here too.

ref: https://github.com/JuliaLang/julia/blob/v0.5.2/deps/pcre.mk#L19