### PR TITLE
Retry Enable JIT (10.21)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/pcre2-feedstock/pull/6 ).

There was already a build number 1 released, which we missed. This bumps the build number to 2 so that we can get a new release with JIT support.