### PR TITLE
Enable macOS (10.21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+os: osx
+osx_image: xcode6.4
+
+env:
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "jLKhEqQGxWPoGJnIJR4/OHY/bkso5wg0acdXCrO9ezO51Ir7XFL6VEWycf8kuv0eT1HzXUWgsaGu1QLDZhk0btRCORBrazQwBUJJ5YvgXmfAIiGtH+Ryd67GEoROnHFWFWQw68yHeZhofHfTK2d/kPg0qds6CO2+YDbpKMcW/g/fZmC/GwScSAW4NDOLfLfFqml4Ef9J29hlSCHn5lx7PNxCbs2w2NYK26nQDB808EMfFGqJWgdqiOBHCiDMi5kx+IyY/EMHm9PpcONp6hBED3pQoOjGai7F7EW1HQa06d2LfH5ijX8yRdbWokpcA3bvp+S4Vy3pMHQtFZHnK0EbTOxjAGRSU2WgkheYhhZwoC54o314Txnp6cWQIz7S8J76TLRMQW9QZM2Z0MXmsLfkPAvDAzkVJG1YuzhSUJNdz2Oe4yRISmBMYOyTpZDia/dhiEdY6F5BvUo9R0z1i25vfKjOVGZjjm0fJ+QumhUOrbG1ehUkVa4sYPQ/SIHcSBnB9Z59komgfsdcLajQrFMjvwCdg/3zDKv0aWSEs+W84QNZ9HEiPY3IuT+RC3KOuGiFWhE8eog795J2OVMtPph8pQTsQQgDsCmz+Pl8fzopeVV87JaBmWx+y5FV22Qr4tSSo2S4jzmD/zTcvF1KK52eA7ij25DDwmp69YXfVcTCaHc="
+
+
+before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
+    # Remove homebrew.
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
+
+install:
+    # Install Miniconda.
+    - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
+      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      bash $MINICONDA_FILE -b
+
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
+      source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
+      conda config --add channels conda-forge
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
+
+script:
+  - conda build ./recipe
+
+  - upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/pcre2-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/pcre2-feedstock)
-OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/pcre2-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/pcre2-feedstock)
 Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
 
 Current release info

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Not only does this hopefully make pcre2 faster,
+# it fixes a test failure on macOS. See link below.
+#
+# ref: https://bugs.exim.org/show_bug.cgi?id=1642
+#
+CFLAGS="${CFLAGS} -O3"
+CXXFLAGS="${CXXFLAGS} -O3"
+
 ./configure \
     --prefix="${PREFIX}" \
     --enable-jit \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 2
-  skip: True  # [not linux]
+  skip: True  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
Partially addresses ( https://github.com/conda-forge/pcre2-feedstock/issues/2 ).

Adds support for macOS builds. Also builds PCRE2 with `-O3`.